### PR TITLE
🛠️ New sim metrics

### DIFF
--- a/hestia/utils/__init__.py
+++ b/hestia/utils/__init__.py
@@ -24,7 +24,7 @@ BULK_SIM_METRICS = {
     'manhattan': bulk_manhattan,
     'euclidean': bulk_euclidean,
     'canberra': bulk_canberra,
-    'mahalanobis': bulk_mahalanobis,
+    'mahalanobis': bulk_mahalanobis(),
     'jensen-shannon': bulk_jensen_shannon,
     'tanimoto-continuous': bulk_tanimoto_continuous
 }

--- a/hestia/utils/__init__.py
+++ b/hestia/utils/__init__.py
@@ -9,7 +9,8 @@ from .bulk_similarity_metrics import (
     bulk_cosine_similarity, bulk_binary_manhattan_similarity,
     bulk_euclidean, bulk_manhattan,
     bulk_np_tanimoto, bulk_np_dice, bulk_np_rogot_goldberg, bulk_np_sokal,
-    bulk_np_jaccard, bulk_canberra)
+    bulk_np_jaccard, bulk_canberra,
+    bulk_mahalanobis, bulk_jensen_shannon, bulk_tanimoto_continuous)
 from .fingerprints import get_fp_function
 
 BULK_SIM_METRICS = {
@@ -22,5 +23,8 @@ BULK_SIM_METRICS = {
     'jaccard': bulk_np_jaccard,
     'manhattan': bulk_manhattan,
     'euclidean': bulk_euclidean,
-    'canberra': bulk_canberra
+    'canberra': bulk_canberra,
+    'mahalanobis': bulk_mahalanobis,
+    'jensen-shannon': bulk_jensen_shannon,
+    'tanimoto-continuous': bulk_tanimoto_continuous
 }

--- a/hestia/utils/bulk_similarity_metrics.py
+++ b/hestia/utils/bulk_similarity_metrics.py
@@ -1,13 +1,114 @@
 import numpy as np
-from sklearn.metrics.pairwise import (cosine_similarity, manhattan_distances,
-                                      euclidean_distances)
+
+from numba import njit
 
 
+@njit
+def bulk_tanimoto_continuous(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    n, d = bulk.shape[0], bulk.shape[1]
+    result = np.empty(n)
+
+    norm_u = 0.0
+    for j in range(d):
+        norm_u += u[j] * u[j]
+
+    for i in range(n):
+        dot = 0.0
+        norm_b = 0.0
+
+        for j in range(d):
+            dot += bulk[i, j] * u[j]
+            norm_b += bulk[i, j] * bulk[i, j]
+
+        denom = norm_u + norm_b - dot
+        result[i] = dot / denom
+
+    return result
+
+
+# @njit
+def bulk_jensen_shannon(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    n, d = bulk.shape
+    distances = np.empty(n)
+
+    # normalize u
+    u_sum = np.sum(u)
+    u_norm = u / u_sum
+
+    for i in range(n):
+        row = bulk[i]
+        row_sum = np.sum(row)
+        row_norm = row / row_sum
+
+        js = 0.0
+        for j in range(d):
+            m = 0.5 * (u_norm[j] + row_norm[j])
+
+            if u_norm[j] > 0:
+                js += 0.5 * u_norm[j] * np.log(u_norm[j] / m)
+            if row_norm[j] > 0:
+                js += 0.5 * row_norm[j] * np.log(row_norm[j] / m)
+
+        distances[i] = np.sqrt(js)
+
+    return distances
+
+
+@njit
+def bulk_mahalanobis(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+    n, d = bulk.shape
+
+    # --- compute mean ---
+    mean = np.zeros(d)
+    for i in range(n):
+        for j in range(d):
+            mean[j] += bulk[i, j]
+    for j in range(d):
+        mean[j] /= n
+
+    # --- compute covariance matrix ---
+    cov = np.zeros((d, d))
+    for i in range(n):
+        for j in range(d):
+            for k in range(d):
+                cov[j, k] += (bulk[i, j] - mean[j]) * (bulk[i, k] - mean[k])
+    for j in range(d):
+        for k in range(d):
+            cov[j, k] /= (n - 1)
+
+    # --- invert covariance (do this once) ---
+    inv_cov = np.linalg.inv(cov)
+
+    # --- compute distances ---
+    distances = np.empty(n)
+    for i in range(n):
+        # temp = inv_cov @ diff
+        temp = np.zeros(d)
+        for j in range(d):
+            for k in range(d):
+                temp[j] += inv_cov[j, k] * (bulk[i, k] - u[k])
+
+        s = 0.0
+        for j in range(d):
+            diff = bulk[i, j] - u[j]
+            s += temp[j] * diff
+
+        distances[i] = np.sqrt(s)
+
+    return distances
+
+
+@njit
 def bulk_np_jaccard(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
-    bits = bulk.shape[1]
-    comp = (bulk == u)
-    counts = comp.sum(1)
-    return counts / bits
+    n, m = bulk.shape
+    out = np.empty(n)
+    for i in range(n):
+        count = 0
+        for j in range(m):
+            if bulk[i, j] == u[j]:
+                count += 1
+        out[i] = count / m
+    return out
 
 
 def bulk_np_tanimoto(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:

--- a/hestia/utils/bulk_similarity_metrics.py
+++ b/hestia/utils/bulk_similarity_metrics.py
@@ -1,114 +1,59 @@
 import numpy as np
 
-from numba import njit
 
-
-@njit
 def bulk_tanimoto_continuous(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
-    n, d = bulk.shape[0], bulk.shape[1]
-    result = np.empty(n)
-
-    norm_u = 0.0
-    for j in range(d):
-        norm_u += u[j] * u[j]
-
-    for i in range(n):
-        dot = 0.0
-        norm_b = 0.0
-
-        for j in range(d):
-            dot += bulk[i, j] * u[j]
-            norm_b += bulk[i, j] * bulk[i, j]
-
-        denom = norm_u + norm_b - dot
-        result[i] = dot / denom
-
+    norm_u = np.dot(u, u)
+    norm_bulk = np.einsum('ij,ij->i', bulk, bulk)
+    dot = bulk @ u
+    result = dot / (norm_u + norm_bulk - dot)
     return result
 
 
-# @njit
 def bulk_jensen_shannon(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
-    n, d = bulk.shape
-    distances = np.empty(n)
+    u_norm = u / np.sum(u)
+    bulk_norm = bulk / np.sum(bulk, axis=1, keepdims=True)
+    m = 0.5 * (bulk_norm + u_norm)
+    mask_u = u_norm > 0
+    mask_bulk = bulk_norm > 0
 
-    # normalize u
-    u_sum = np.sum(u)
-    u_norm = u / u_sum
+    js = (0.5 * np.sum(u_norm * np.log(u_norm / m), axis=1) * mask_u[:, None] +
+          0.5 * np.sum(bulk_norm * np.log(bulk_norm / m), axis=1) * mask_bulk)
+    return np.sqrt(js)
 
-    for i in range(n):
-        row = bulk[i]
-        row_sum = np.sum(row)
-        row_norm = row / row_sum
 
-        js = 0.0
-        for j in range(d):
-            m = 0.5 * (u_norm[j] + row_norm[j])
-
-            if u_norm[j] > 0:
-                js += 0.5 * u_norm[j] * np.log(u_norm[j] / m)
-            if row_norm[j] > 0:
-                js += 0.5 * row_norm[j] * np.log(row_norm[j] / m)
-
-        distances[i] = np.sqrt(js)
-
+def bulk_mahalanobis_core(u: np.ndarray, bulk: np.ndarray, inv_cov: np.ndarray) -> np.ndarray:
+    diffs = bulk - u
+    left = diffs @ inv_cov
+    sq_distances = np.sum(left * diffs, axis=1)
+    sq_distances = np.maximum(sq_distances, 0.0)
+    distances = np.sqrt(sq_distances)
     return distances
 
 
-@njit
-def bulk_mahalanobis(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
-    n, d = bulk.shape
+class bulk_mahalanobis:
+    def __init__(self):
+        self.prev_bulk_id = None
+        self.inv_cov = None
+        self.mean = None
 
-    # --- compute mean ---
-    mean = np.zeros(d)
-    for i in range(n):
-        for j in range(d):
-            mean[j] += bulk[i, j]
-    for j in range(d):
-        mean[j] /= n
+    def __call__(self, u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
+        if self.prev_bulk_id != id(bulk):
+            mean = bulk.mean(axis=0)
+            X_centered = bulk - mean
+            cov = (X_centered.T @ X_centered) / (bulk.shape[0] - 1)
+            inv_cov = np.linalg.inv(cov)
+            self.mean = mean
+            self.inv_cov = inv_cov
+            self.prev_bulk_id = id(bulk)
 
-    # --- compute covariance matrix ---
-    cov = np.zeros((d, d))
-    for i in range(n):
-        for j in range(d):
-            for k in range(d):
-                cov[j, k] += (bulk[i, j] - mean[j]) * (bulk[i, k] - mean[k])
-    for j in range(d):
-        for k in range(d):
-            cov[j, k] /= (n - 1)
-
-    # --- invert covariance (do this once) ---
-    inv_cov = np.linalg.inv(cov)
-
-    # --- compute distances ---
-    distances = np.empty(n)
-    for i in range(n):
-        # temp = inv_cov @ diff
-        temp = np.zeros(d)
-        for j in range(d):
-            for k in range(d):
-                temp[j] += inv_cov[j, k] * (bulk[i, k] - u[k])
-
-        s = 0.0
-        for j in range(d):
-            diff = bulk[i, j] - u[j]
-            s += temp[j] * diff
-
-        distances[i] = np.sqrt(s)
-
-    return distances
+        return bulk_mahalanobis_core(u, bulk, self.inv_cov)
 
 
-@njit
 def bulk_np_jaccard(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:
-    n, m = bulk.shape
-    out = np.empty(n)
-    for i in range(n):
-        count = 0
-        for j in range(m):
-            if bulk[i, j] == u[j]:
-                count += 1
-        out[i] = count / m
-    return out
+    bits = bulk.shape[1]
+    comp = (bulk == u)
+    counts = comp.sum(1)
+    return counts / bits
 
 
 def bulk_np_tanimoto(u: np.ndarray, bulk: np.ndarray) -> np.ndarray:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ requirements = [
     'numpy',
     'tqdm',
     'pyarrow',
-    'pyyaml'
+    'pyyaml',
+    'numba'
 ]
 
 test_requirements = requirements


### PR DESCRIPTION
- Tanimoto-continuous: Acceleration 0.85s (100 x (bulk=1000x1000)) vs 45s
- Jensen-Shannon: Acceleration 3.5s (100 x (bulk=1000x1000)) vs > 170s

Even though numba accelerates with regards to the pure Python implementation, numpy vectorization is still one order of magnitude faster